### PR TITLE
Handle Recursive Loop in BlazorChecker

### DIFF
--- a/AsyncApostle/AsyncHelpers/ConfigureAwaitCheckers/CustomCheckers/BlazorChecker.cs
+++ b/AsyncApostle/AsyncHelpers/ConfigureAwaitCheckers/CustomCheckers/BlazorChecker.cs
@@ -16,20 +16,29 @@ class BlazorChecker : IConfigureAwaitCustomChecker
    static IDeclaredType? FindComponentBaseClass(IEnumerable<IDeclaredType> superTypes)
    {
       var declaredTypes = superTypes.ToList();
+      var visited = new HashSet<IDeclaredType>();
 
-      foreach (var declaredType in declaredTypes)
+      return FindComponentBaseClassInternal(declaredTypes);
+
+      IDeclaredType? FindComponentBaseClassInternal(IEnumerable<IDeclaredType> types)
       {
-         if (declaredType.GetSuperTypes()
-                         .Any(static i => i.GetClrName()
-                                           .FullName.Equals(COMPONENT_BASE_NAME)))
-            return declaredType;
+         foreach (var declaredType in types)
+         {
+            if (!visited.Add(declaredType))
+               continue;
 
-         var componentDeclaration = FindComponentBaseClass(declaredType.GetSuperTypes());
+            if (declaredType.GetSuperTypes()
+                            .Any(static i => i.GetClrName()
+                                              .FullName.Equals(COMPONENT_BASE_NAME)))
+               return declaredType;
 
-         if (componentDeclaration is not null) return componentDeclaration;
+            var componentDeclaration = FindComponentBaseClassInternal(declaredType.GetSuperTypes());
+
+            if (componentDeclaration is not null) return componentDeclaration;
+         }
+
+         return null;
       }
-
-      return null;
    }
 
    static IClassDeclaration? GetClassDeclaration(ITreeNode? node) =>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
       <OutputPath>bin\$(MSBuildProjectName)\$(Configuration)\</OutputPath>
       <TargetFramework>net472</TargetFramework>
       <Title>AsyncApostle</Title>
-      <Version>2025.2.0</Version>
+      <Version>2025.2.1-beta01</Version>
    </PropertyGroup>
 
    <ItemGroup>

--- a/Rider/AsyncApostle.Rider/META-INF/plugin.xml
+++ b/Rider/AsyncApostle.Rider/META-INF/plugin.xml
@@ -15,7 +15,7 @@
                    <li>Analyze usage of a processed method. If the method is called from async context the AsyncApostle will replace its call with the await expression, otherwise it will just call .Result or .Wait()</li>
                </ol>]]>
    </description>
-   <version>2025.2.0</version>
+   <version>2025.2.1-beta01</version>
    <vendor url="https://github.com/phasTrak/AsyncApostle">phasTrak</vendor>
    <idea-version since-build="233"
                  until-build="252.*"/>

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -15,7 +15,7 @@ class Build : NukeBuild
 
    public override AbsolutePath ArtifactsDirectory => SolutionDirectory / "packages";
 
-   static          string       Version            => "2025.2.0";
+   static          string       Version            => "2025.2.1-beta01";
 
    Target Clean =>
       d => d.Executes(() =>


### PR DESCRIPTION
In some scenarios, while determining the base class for components, the BlazorChecker was encountering a recursive loop leading to a StackOverflowException and crashing the IDE.

This PR solves this issue by keeping track of all the visited types to ensure the same type is not checked infinitely.

- Introduced a private helper method `FindComponentBaseClassInternal`.
- Added a `HashSet<IDeclaredType>` to track visited types.
- Replaced the `foreach` loop in `FindComponentBaseClass` with a call to the helper method.
- Moved recursive logic into `FindComponentBaseClassInternal`.
- Prevented redundant processing by skipping already-visited types.
- Added a check for supertypes matching `COMPONENT_BASE_NAME` in the helper method.
- Ensured recursive calls are made on the super types of each `declaredType`.
- Removed redundant `return null` from the original method.
- Improved code readability and maintainability.
- Enhanced efficiency by avoiding unnecessary iterations.

Fixes #16
Fixes #19 